### PR TITLE
Update Item.php

### DIFF
--- a/app/code/community/Etailer/Backorders/Model/Stock/Item.php
+++ b/app/code/community/Etailer/Backorders/Model/Stock/Item.php
@@ -20,5 +20,22 @@ class Etailer_Backorders_Model_Stock_Item extends Mage_CatalogInventory_Model_St
         }
         return true;
     }
+    
+     /**
+     * Check if item should be in stock or out of stock based on $qty param of existing item qty
+     *
+     * @param float|null $qty
+     * @return bool true - item in stock | false - item out of stock
+     */
+    public function verifyStock($qty = null)
+    {
+        if ($qty === null) {
+            $qty = $this->getQty();
+        }
+        if ($qty <= $this->getMinQty()) {
+            return false;
+        }
+        return true;
+    }
 
 }


### PR DESCRIPTION
I was having the issue, of "Out of Stock" not being set once the "Qty*" went below "Qty for Item's Status to Become Out of Stock" as a result of a customer buying a product.

The fix I did was in: Etailer_Backorders-master/app/code/community/Etailer/Backorders/Model/Item.php

You have to over ride the core function verifyStock. This is because the original function ignores quantity settings if Backorders is set to "No Backorders"
