### PR TITLE
Allow new bottom of $this->getMinQty() for backorder products only, n…

### DIFF
--- a/app/code/community/Etailer/Backorders/Model/Stock/Item.php
+++ b/app/code/community/Etailer/Backorders/Model/Stock/Item.php
@@ -15,9 +15,16 @@ class Etailer_Backorders_Model_Stock_Item extends Mage_CatalogInventory_Model_St
             return true;
         }
 
-        if ($this->getQty() - $this->getMinQty() - $qty < 0) {
-            return false;
-        }
+		// Allow new bottom of $this->getMinQty() for backorder products only, normal freeze at 0
+        if ($this->getBackorders()) {
+			if ($this->getQty() - $this->getMinQty() - $qty < 0) {
+				return false;
+			}
+		} else {
+			if ($this->getQty() - $qty < 0) {
+				return false;
+			}	
+		}
         return true;
     }
     
@@ -32,9 +39,16 @@ class Etailer_Backorders_Model_Stock_Item extends Mage_CatalogInventory_Model_St
         if ($qty === null) {
             $qty = $this->getQty();
         }
-        if ($qty <= $this->getMinQty()) {
-            return false;
-        }
+       // Allow new bottom of $this->getMinQty() for backorder products only, normal freeze at 0
+        if ($this->getBackorders()) {
+			if ($qty <= $this->getMinQty()) {
+				return false;
+			}
+		} else {
+			if ($qty <= 0) {
+				return false;
+			}
+		}
         return true;
     }
 


### PR DESCRIPTION
…ormal freeze at 0

Fixes problem where when product edit and save like
P1: qty=0; min_qty=-2;No backorders;In stock

Expected result
qty=0; min_qty=-2;No backorders;Out of Stock (as qty =0 and no backorders allowed)

Actual result
qty=0; min_qty=-2;No backorders;In stock (min_qty also is allowed for normal products, but seeing we have this new behavior I can only assume one would *only* want this for backorderable products)